### PR TITLE
chore: 행동대장 todari.dev 서브도메인 이전

### DIFF
--- a/apps/client/env.prod.example
+++ b/apps/client/env.prod.example
@@ -6,5 +6,11 @@
 # 전체 URL = https://도메인 + KAKAO_REDIRECT_URI
 KAKAO_REDIRECT_URI=/login/kakao
 
+# API 요청은 같은 도메인의 /api 프록시를 사용합니다.
+API_BASE_URL=https://haengdong.todari.dev
+
+# CloudFront 기본 도메인을 사용해 서비스 도메인 만료와 분리합니다.
+IMAGE_URL=https://d392hh8td3eqj7.cloudfront.net
+
 # Google Analytics 4 Measurement ID
 GA_MEASUREMENT_ID=G-R1WQ0R2L50

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -11,7 +11,7 @@
       content="행동대장, 행대동장, 행댕이, 흔듯, 행사, 정산, 모임, 송금, 더치페이, 더치페이 서비스, 더치페이 앱, 간편 정산, 간편한 정산, 쉬운 정산, 정산 앱, 정산 서비스, 엔빵, 엔빵계산기, 엔빵 앱, 엔빵 서비스, 우아한테크코스, 우테코, 우테코 프로젝트, 우테코 6기, 우아한테크코스 6기"
     />
 
-    <meta property="og:url" content="https://haengdong.pro/" />
+    <meta property="og:url" content="https://haengdong.todari.dev/" />
     <meta property="og:site_name" content="행동대장" />
     <meta property="og:title" content="행동대장 - 쉽고 빠른 모임 정산 및 송금 서비스" />
     <meta property="og:description" content="행동대장으로 모임에서 발생한 비용을 손쉽게 정산하고 간편하게 송금해요" />
@@ -40,7 +40,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0" />
 
-    <link rel="canonical" href="https://haengdong.pro/" />
+    <link rel="canonical" href="https://haengdong.todari.dev/" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon" href="/favicon.ico" />
 
@@ -50,27 +50,27 @@
         "@graph": [
           {
             "@type": "WebSite",
-            "@id": "https://haengdong.pro/#website",
-            "url": "https://haengdong.pro/",
+            "@id": "https://haengdong.todari.dev/#website",
+            "url": "https://haengdong.todari.dev/",
             "name": "행동대장",
             "description": "모임에서 발생한 비용을 쉽게 정산하고 간편하게 송금하는 무료 더치페이 서비스",
             "inLanguage": "ko-KR",
-            "publisher": { "@id": "https://haengdong.pro/#org" }
+            "publisher": { "@id": "https://haengdong.todari.dev/#org" }
           },
           {
             "@type": "Organization",
-            "@id": "https://haengdong.pro/#org",
+            "@id": "https://haengdong.todari.dev/#org",
             "name": "행동대장",
-            "url": "https://haengdong.pro/",
+            "url": "https://haengdong.todari.dev/",
             "logo": "https://wooteco-crew-wiki.s3.ap-northeast-2.amazonaws.com/%EC%BF%A0%ED%82%A4%286%EA%B8%B0%29/4tyq1x19rsn.jpg"
           },
           {
             "@type": "SoftwareApplication",
-            "@id": "https://haengdong.pro/#app",
+            "@id": "https://haengdong.todari.dev/#app",
             "name": "행동대장",
             "applicationCategory": "FinanceApplication",
             "operatingSystem": "Web",
-            "url": "https://haengdong.pro/",
+            "url": "https://haengdong.todari.dev/",
             "description": "여행·모임 비용을 가입 없이 쉽게 정산하고 송금. 구성원 변동에도 자동 재계산.",
             "inLanguage": "ko-KR",
             "offers": { "@type": "Offer", "price": "0", "priceCurrency": "KRW" },

--- a/apps/client/public/robots.txt
+++ b/apps/client/public/robots.txt
@@ -4,4 +4,4 @@ Disallow: /event/*/admin
 Disallow: /login
 Disallow: /setting
 
-Sitemap: https://haengdong.pro/sitemap.xml
+Sitemap: https://haengdong.todari.dev/sitemap.xml

--- a/apps/client/public/sitemap.xml
+++ b/apps/client/public/sitemap.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://haengdong.pro/</loc>
+    <loc>https://haengdong.todari.dev/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://haengdong.pro/login</loc>
+    <loc>https://haengdong.todari.dev/login</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://haengdong.pro/event/create/guest</loc>
+    <loc>https://haengdong.todari.dev/event/create/guest</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://haengdong.pro/event/create/user</loc>
+    <loc>https://haengdong.todari.dev/event/create/user</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/apps/client/src/utils/getEventPageUrlByEnvironment.ts
+++ b/apps/client/src/utils/getEventPageUrlByEnvironment.ts
@@ -3,9 +3,7 @@ import {ROUTER_URLS} from '@constants/routerUrls';
 type EventPageTab = 'home' | 'admin';
 
 const getEventPageUrlByEnvironment = (eventId: string, tab: EventPageTab) => {
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
-  return `https://${isDevelopment ? 'dev.' : ''}haengdong.pro${ROUTER_URLS.event}/${eventId}/${tab}`;
+  return `${window.location.origin}${ROUTER_URLS.event}/${eventId}/${tab}`;
 };
 
 export default getEventPageUrlByEnvironment;

--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -4,6 +4,10 @@
   "outputDirectory": "dist",
   "framework": null,
   "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "http://52.78.45.209:8080/api/:path*"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
 
 cors:
   max-age: 3600
-  allowed-origins: http://localhost:3000, https://haengdong.pro, https://dev.haengdong.pro, https://app.haengdong.pro
+  allowed-origins: http://localhost:3000, https://haengdong.todari.dev
 
 security:
   jwt:


### PR DESCRIPTION
## 변경 사항
- 서비스 공개 URL을 `https://haengdong.todari.dev`로 변경
- 공유 링크가 현재 origin을 사용하도록 변경
- `/api` 요청을 Vercel에서 기존 NestJS 서버로 프록시
- 이미지 URL을 CloudFront 기본 도메인으로 분리
- SEO canonical, Open Graph, JSON-LD, robots, sitemap 갱신

## 검증
- `pnpm --filter @haeng-dong/shared build` 통과
- 프로덕션 클라이언트 빌드 통과
- 변경 유틸 단일 ESLint 통과
- 전체 lint는 기존 포매팅/정렬 오류 21건으로 실패
- 전체 test는 기존 SVG Jest 변환 오류로 2건 실패