### PR TITLE
chore: API를 todari.dev 서브도메인으로 이전

### DIFF
--- a/apps/client/env.prod.example
+++ b/apps/client/env.prod.example
@@ -6,8 +6,8 @@
 # 전체 URL = https://도메인 + KAKAO_REDIRECT_URI
 KAKAO_REDIRECT_URI=/login/kakao
 
-# API 요청은 같은 도메인의 /api 프록시를 사용합니다.
-API_BASE_URL=https://haengdong.todari.dev
+# EC2 API 서버의 HTTPS 주소
+API_BASE_URL=https://api.haengdong.todari.dev
 
 # CloudFront 기본 도메인을 사용해 서비스 도메인 만료와 분리합니다.
 IMAGE_URL=https://d392hh8td3eqj7.cloudfront.net

--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -4,10 +4,6 @@
   "outputDirectory": "dist",
   "framework": null,
   "rewrites": [
-    {
-      "source": "/api/:path*",
-      "destination": "http://52.78.45.209:8080/api/:path*"
-    },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/deploy/nginx/api.haengdong.todari.dev.conf
+++ b/deploy/nginx/api.haengdong.todari.dev.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.haengdong.todari.dev;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## 변경 사항
- API 주소를 `https://api.haengdong.todari.dev`로 변경
- Vercel의 HTTP EC2 프록시 제거
- EC2 Nginx 설정을 저장소에 추가

## 검증
- shared TypeScript build 통과
- 새 API 주소를 주입한 client production build 통과
- EC2 Nginx 설정 검사 및 HTTP Host 프록시 응답 확인

DNS와 TLS 인증서 확인 후 머지합니다.