### PR TITLE
fix(client): ignore injected iOS webview Sentry noise

### DIFF
--- a/apps/client/src/utils/sentry.ts
+++ b/apps/client/src/utils/sentry.ts
@@ -2,6 +2,11 @@ import * as Sentry from '@sentry/react';
 
 let initialized = false;
 
+// Haengdong is a regular web app and never calls a WKWebView message handler.
+// Some iOS in-app browsers inject a native bridge script that assumes this
+// object exists; its uncaught exception is third-party noise, not an app error.
+const injectedWebViewErrors = [/window\.webkit\.messageHandlers/u];
+
 export function initSentry() {
   if (initialized) return;
   const dsn = process.env.SENTRY_DSN;
@@ -11,6 +16,7 @@ export function initSentry() {
     environment: process.env.NODE_ENV || 'development',
     tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0),
     initialScope: {tags: {service: 'haengdong'}},
+    ignoreErrors: injectedWebViewErrors,
   });
   initialized = true;
 }


### PR DESCRIPTION
## Summary

- Ignore the exact window.webkit.messageHandlers exception injected by some iOS in-app browsers.
- Keep all application-originated Sentry errors enabled.

## Verification

- pnpm --filter @haeng-dong/client lint
- pnpm --filter @haeng-dong/client exec jest --runInBand --no-watchman (15 passed)
- pnpm --filter @haeng-dong/client build
